### PR TITLE
Bootstrap a Basic API

### DIFF
--- a/data/serializers.py
+++ b/data/serializers.py
@@ -1,0 +1,21 @@
+
+from rest_framework.serializers import ModelSerializer
+from data.models import Thing, SubThing, UnrelatedThing
+
+
+class ThingSerializer(ModelSerializer):
+    class Meta:
+        model = Thing
+        fields = '__all__'
+
+
+class SubThingSerializer(ModelSerializer):
+    class Meta:
+        model = SubThing
+        fields = '__all__'
+
+
+class UnrelatedThingSerializer(ModelSerializer):
+    class Meta:
+        model = UnrelatedThing
+        fields = '__all__'

--- a/data/urls.py
+++ b/data/urls.py
@@ -1,0 +1,10 @@
+
+from rest_framework.routers import DefaultRouter
+
+from data.views import ThingViewSet, SubThingViewSet, UnrelatedThingViewSet
+
+router = DefaultRouter()
+router.register(r'things', ThingViewSet, basename='thing')
+router.register(r'subthings', SubThingViewSet, basename='subthing')
+router.register(r'unrelated_things', UnrelatedThingViewSet, basename='unrelated_thing')
+urlpatterns = router.urls

--- a/data/views.py
+++ b/data/views.py
@@ -1,3 +1,20 @@
+
 from django.shortcuts import render
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
+from data.models import Thing, SubThing, UnrelatedThing
+from data.serializers import ThingSerializer, SubThingSerializer, UnrelatedThingSerializer
 
 # Create your views here.
+
+class ThingViewSet(ReadOnlyModelViewSet):
+    queryset = Thing.objects.all()
+    serializer_class = ThingSerializer
+
+class SubThingViewSet(ReadOnlyModelViewSet):
+    queryset = SubThing.objects.all()
+    serializer_class = SubThingSerializer
+
+class UnrelatedThingViewSet(ReadOnlyModelViewSet):
+    queryset = UnrelatedThing.objects.all()
+    serializer_class = UnrelatedThingSerializer

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
 
   app:
     build: .
-    restart: always # comment out this line prior to one off run commands
+    # restart: always # comment out this line prior to one off run commands
     depends_on:
       - db
     env_file: .env

--- a/prototype/settings.py
+++ b/prototype/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'data'
 ]
 
@@ -123,3 +124,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100
+}

--- a/prototype/urls.py
+++ b/prototype/urls.py
@@ -14,8 +14,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
+
+import data.urls
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('data/', include('data.urls'))
 ]


### PR DESCRIPTION
## Description

This is a bootstrap of a basic read-only API for this prototype project such that data can be accessed. This has been implemented using Django Rest Framework's `ReadOnlyModelViewSet`.

## Scope of Impact
- Serializers for each Model in the Data App.
- ReadOnlyModelViewSets for each Model in the Data App.
- A URLs implementation to expose the aforementioned ReadOnlyModelViewSets.
- Minor Django Rest Framework Tweaks to project settings.
- The `restart: always` policy on the App service in the Docker Compose specification has been commented out until further notice for the sake of easing development.